### PR TITLE
Update 02-introduction-to-git.md

### DIFF
--- a/episodes/02-introduction-to-git.md
+++ b/episodes/02-introduction-to-git.md
@@ -5,7 +5,7 @@
 ### Instructor Notes
 Lesson material: https://swcarpentry.github.io/git-novice/
 Slides (optional, but nice and helpful to show): https://nlesc-slides.github.io/2023-06-19-ds-cr/git/. This is our suggestion for when to use the slides:
-- Slides 0 - 4: right before episode 1 (Automated Version Control)
+- Slides 0 - 4: accompanying episode 1 (Automated Version Control)
 - Slides 5 - 9: right after episode 4 (Tracking Changes)
 
 NB: Optional day before the course starts for participants who don’t know the git basics yet.

--- a/episodes/02-introduction-to-git.md
+++ b/episodes/02-introduction-to-git.md
@@ -6,7 +6,9 @@
 Lesson material: https://swcarpentry.github.io/git-novice/
 Slides (optional, but nice and helpful to show): https://nlesc-slides.github.io/2023-06-19-ds-cr/git/. This is our suggestion for when to use the slides:
 - Slides 0 - 4: accompanying episode 1 (Automated Version Control)
-- Slides 5 - 9: right after episode 4 (Tracking Changes)
+- Slides 5 - 9: accompanying episode 4 (Tracking Changes)
+
+The slides provide visual context to the concepts that are used in the live coding. Especially for episode 4 (Tracking Changes) it would be best to have both the live coding screen and the slides screen side by side. As this is in general not possible, it is best to switch back and forth between command line and slides when necessary (you can use the images in the teaching material as indication when to switch to the slides).
 
 NB: Optional day before the course starts for participants who don’t know the git basics yet.
 

--- a/episodes/02-introduction-to-git.md
+++ b/episodes/02-introduction-to-git.md
@@ -4,9 +4,9 @@
 
 ### Instructor Notes
 Lesson material: https://swcarpentry.github.io/git-novice/
-Slides (optional, but nice and helpful to show): https://nlesc-slides.github.io/2023-06-19-ds-cr/git/. In particular:
-- Slides 0 - 4: before episode 1 (Automated Version Control)
-- Slides 5 - 9: after episode 4 (Tracking Changes)
+Slides (optional, but nice and helpful to show): https://nlesc-slides.github.io/2023-06-19-ds-cr/git/. This is our suggestion for when to use the slides:
+- Slides 0 - 4: right before episode 1 (Automated Version Control)
+- Slides 5 - 9: right after episode 4 (Tracking Changes)
 
 NB: Optional day before the course starts for participants who don’t know the git basics yet.
 

--- a/episodes/02-introduction-to-git.md
+++ b/episodes/02-introduction-to-git.md
@@ -3,7 +3,10 @@
 3:12 hours (this is according to the carpentries, but it is not accurate, see below)
 
 ### Instructor Notes
-Lesson material: https://swcarpentry.github.io/git-novice/ 
+Lesson material: https://swcarpentry.github.io/git-novice/
+Slides (optional, but nice and helpful to show): https://nlesc-slides.github.io/2023-06-19-ds-cr/git/. In particular:
+- Slides 0 - 4: before episode 1 (Automated Version Control)
+- Slides 5 - 9: after episode 4 (Tracking Changes)
 
 NB: Optional day before the course starts for participants who don’t know the git basics yet.
 


### PR DESCRIPTION
I inserted a reference to the new slides we have (the ones created by Barbara and Ole), and instructions for how to use them with the carpentry episodes.
Also, I see that the link to the slides is [...]/2023-06-19-ds-cr, but I think that the slides were created later. Should we update it as well?

I assigned @JaroCamphuijsen as well as a reviewer since we were both teaching the intro to git episode. 

Should we create an issue with different tasks for this PR and the other ones that we'll open? @lyashevska 

 